### PR TITLE
Add Jest setup and test for validation helper

### DIFF
--- a/app/api/candidates/route.ts
+++ b/app/api/candidates/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
   }
 }
 
-function isValidationError(
+export function isValidationError(
   error: unknown
 ): error is { name: string; message: string } {
   return (

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: 'tsconfig.json'
+    }
+  }
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "ts-node --esm scripts/seedCandidates.ts"
+    "seed": "ts-node --esm scripts/seedCandidates.ts",
+    "test": "jest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",
@@ -29,6 +30,9 @@
     "eslint-config-next": "15.3.1",
     "tailwindcss": "^4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.5"
   }
 }

--- a/tests/isValidationError.test.ts
+++ b/tests/isValidationError.test.ts
@@ -1,0 +1,14 @@
+import { isValidationError } from '../app/api/candidates/route';
+
+describe('isValidationError', () => {
+  it('returns true for mongoose validation errors', () => {
+    const error = { name: 'ValidationError', message: 'invalid' };
+    expect(isValidationError(error)).toBe(true);
+  });
+
+  it('returns false for non-validation errors', () => {
+    const otherError = { name: 'OtherError', message: 'wrong' };
+    expect(isValidationError(otherError)).toBe(false);
+    expect(isValidationError(new Error('oops'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest with TypeScript support
- expose `isValidationError` helper for testing
- create Jest config
- add unit test for `isValidationError`

## Testing
- `npm test` *(fails: jest not found)*