### PR TITLE
Fix invalid export in candidates route

### DIFF
--- a/app/api/candidates/route.ts
+++ b/app/api/candidates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/dbConnect";
 import Candidates from "@/lib/models/Candidates";
+import { isValidationError } from "@/lib/isValidationError";
 
 export async function GET(req: NextRequest) {
   await dbConnect();
@@ -56,13 +57,3 @@ export async function POST(req: NextRequest) {
   }
 }
 
-export function isValidationError(
-  error: unknown
-): error is { name: string; message: string } {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "name" in error &&
-    error.name === "ValidationError"
-  );
-}

--- a/lib/isValidationError.ts
+++ b/lib/isValidationError.ts
@@ -1,0 +1,10 @@
+export function isValidationError(
+  error: unknown
+): error is { name: string; message: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "ValidationError"
+  );
+}

--- a/tests/isValidationError.test.ts
+++ b/tests/isValidationError.test.ts
@@ -1,4 +1,4 @@
-import { isValidationError } from '../app/api/candidates/route';
+import { isValidationError } from '../lib/isValidationError';
 
 describe('isValidationError', () => {
   it('returns true for mongoose validation errors', () => {


### PR DESCRIPTION
## Summary
- move `isValidationError` helper out of API route
- update references in API route and tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_683fa0a3c358832bae1ac65a287a329c