### PR TITLE
Add basic user profile APIs and page

### DIFF
--- a/app/api/routines/route.ts
+++ b/app/api/routines/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+const routines = [
+  {
+    name: "Arnold Split",
+    days: 6,
+    description:
+      "Classic bodybuilding routine alternating push, pull and legs with high volume.",
+  },
+  {
+    name: "Full Body",
+    days: 3,
+    description: "A balanced routine hitting all major muscle groups each session.",
+  },
+];
+
+export async function GET() {
+  return NextResponse.json(routines, { status: 200 });
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import dbConnect from "@/lib/dbConnect";
+import User from "@/lib/models/User";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  await dbConnect();
+  try {
+    const user = await User.findById(params.id);
+    if (!user) {
+      return NextResponse.json({ message: "User not found" }, { status: 404 });
+    }
+    return NextResponse.json(user, { status: 200 });
+  } catch (err) {
+    return NextResponse.json(
+      { message: "Failed to fetch user", error: err },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  await dbConnect();
+  const role = req.headers.get("x-role") || "user";
+  const body = await req.json();
+
+  if ("diet" in body && role !== "nutritionist") {
+    return NextResponse.json(
+      { message: "Forbidden: insufficient permissions" },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const user = await User.findByIdAndUpdate(params.id, body, {
+      new: true,
+      runValidators: true,
+    });
+    if (!user) {
+      return NextResponse.json({ message: "User not found" }, { status: 404 });
+    }
+    return NextResponse.json(user, { status: 200 });
+  } catch (err) {
+    return NextResponse.json(
+      { message: "Failed to update user", error: err },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import dbConnect from "@/lib/dbConnect";
+import User from "@/lib/models/User";
+import { isValidationError } from "@/lib/isValidationError";
+
+export async function POST(req: NextRequest) {
+  await dbConnect();
+  try {
+    const body = await req.json();
+    const created = await User.create(body);
+    return NextResponse.json(created, { status: 201 });
+  } catch (err: unknown) {
+    if (isValidationError(err)) {
+      return NextResponse.json(
+        { message: "Validation Error", error: err.message },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      { message: "Internal Server Error", error: err },
+      { status: 500 }
+    );
+  }
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+
+interface User {
+  _id: string;
+  name: string;
+  email: string;
+  photo?: string;
+  age?: number;
+  sex?: string;
+  height?: number;
+  currentWeight?: number;
+  diet?: string;
+  gymRoutine?: string;
+}
+
+export default function ProfilePage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [routines, setRoutines] = useState<{ name: string; description: string }[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("voter");
+    if (stored) {
+      const candidate = JSON.parse(stored) as { _id: string };
+      fetch(`/api/users/${candidate._id}`)
+        .then((res) => res.json())
+        .then(setUser)
+        .catch(() => {});
+    }
+    fetch("/api/routines")
+      .then((res) => res.json())
+      .then(setRoutines)
+      .catch(() => {});
+  }, []);
+
+  if (!user) {
+    return <div className="min-h-screen flex items-center justify-center">Cargando...</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto text-white">
+      <div className="flex flex-col items-center gap-4 bg-black/50 p-4 rounded-xl">
+        {user.photo && (
+          <Image src={user.photo} alt={user.name} width={150} height={150} className="rounded-full" />
+        )}
+        <h1 className="text-2xl font-bold">{user.name}</h1>
+        <p>Edad: {user.age ?? "N/A"}</p>
+        <p>Sexo: {user.sex ?? "N/A"}</p>
+        <p>Altura: {user.height ?? "N/A"} cm</p>
+        <p>Peso actual: {user.currentWeight ?? "N/A"} kg</p>
+        {user.diet && (
+          <div className="w-full mt-4">
+            <h2 className="text-xl font-semibold mb-2">Dieta actual</h2>
+            <p className="whitespace-pre-line">{user.diet}</p>
+          </div>
+        )}
+        <div className="w-full mt-4">
+          <h2 className="text-xl font-semibold mb-2">Rutinas de gimnasio</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            {routines.map((r) => (
+              <li key={r.name}>
+                <strong>{r.name}:</strong> {r.description}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/models/User.ts
+++ b/lib/models/User.ts
@@ -1,0 +1,19 @@
+import { Schema, model, models } from "mongoose";
+
+const UserSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, unique: true, required: true },
+    photo: String,
+    age: Number,
+    sex: String,
+    height: Number,
+    currentWeight: Number,
+    diet: String,
+    gymRoutine: String,
+    role: { type: String, enum: ["user", "nutritionist"], default: "user" },
+  },
+  { timestamps: true }
+);
+
+export default models.User || model("User", UserSchema);

--- a/tests/routines.test.ts
+++ b/tests/routines.test.ts
@@ -1,0 +1,10 @@
+import { GET } from "../app/api/routines/route";
+
+describe("GET /api/routines", () => {
+  it("returns a list of routines", async () => {
+    const response = await GET();
+    const data = await response.json();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `User` mongoose model
- expose profile API endpoints for getting and updating users
- add API for listing predefined gym routines
- create client profile page with diet and routine display
- add unit test for routines API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850b458b088832b85aa308ed06f95e0