### PR TITLE
Remove header/footer from login and signup pages

### DIFF
--- a/app/components/PageLayout.tsx
+++ b/app/components/PageLayout.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { usePathname } from "next/navigation";
+import Header from "./Header";
+import Footer from "./Footer";
+
+export default function PageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const hideLayout = pathname.startsWith("/login") || pathname.startsWith("/signup");
+
+  return (
+    <>
+      {!hideLayout && <Header />}
+      {children}
+      {!hideLayout && <Footer />}
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Header from "./components/Header";
-import Footer from "./components/Footer";
+import PageLayout from "./components/PageLayout";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,10 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Header />
-
-        {children}
-        <Footer />
+        <PageLayout>{children}</PageLayout>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add `PageLayout` client component for conditional header/footer display
- use `PageLayout` in root layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850bbde8b8c832bbbc2138ca73e302b