### PR TITLE
Add CLI utility for creating users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 
 This app requires a MongoDB connection string. Define the `MONGODB_URI` environment variable (for example in a `.env.local` file) before starting the server. Running the app without this variable causes `lib/dbConnect.ts` to throw an error during initialization.
 
+### Creating Users
+
+To create a user directly from the command line run:
+
+```bash
+npm run create-user -- <email> <password> <name> [age]
+```
+
+The script connects to your MongoDB instance using `MONGODB_URI` and stores the new user.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "seed": "ts-node --esm scripts/seedCandidates.ts",
+    "create-user": "ts-node --esm scripts/createUser.ts",
     "test": "jest"
   },
   "dependencies": {

--- a/scripts/createUser.ts
+++ b/scripts/createUser.ts
@@ -1,0 +1,35 @@
+import dbConnect from "@/lib/dbConnect";
+import User from "@/lib/models/User";
+
+async function main() {
+  const [, , email, password, name, age] = process.argv;
+  if (!email || !password || !name) {
+    console.error(
+      "Usage: ts-node --esm scripts/createUser.ts <email> <password> <name> [age]"
+    );
+    process.exit(1);
+  }
+
+  await dbConnect();
+
+  const existing = await User.findOne({ email });
+  if (existing) {
+    console.error("User already exists");
+    process.exit(1);
+  }
+
+  const user = await User.create({
+    email,
+    password,
+    name,
+    age: age ? Number(age) : undefined,
+  });
+
+  console.log(`Created user with id ${user._id}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Failed to create user", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a small CLI script to create users via Mongoose
- document usage in README
- expose the script via an npm script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850cf5f03bc832b9c8548a4362ce4ee