### PR TITLE
Add login password check and profile fix

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -20,7 +20,7 @@ export default function ProfilePage() {
   const [routines, setRoutines] = useState<{ name: string; description: string }[]>([]);
 
   useEffect(() => {
-    const stored = localStorage.getItem("voter");
+    const stored = localStorage.getItem("user");
     if (stored) {
       const candidate = JSON.parse(stored) as { _id: string };
       fetch(`/api/users/${candidate._id}`)


### PR DESCRIPTION
## Summary
- read the logged-in user from `localStorage` in the profile page
- keep login API verifying password with bcrypt

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850d5eb5f3c832b96cdf9599e928d36