### PR TITLE
Add weight progress tracking

### DIFF
--- a/lib/models/User.ts
+++ b/lib/models/User.ts
@@ -10,6 +10,13 @@ const UserSchema = new Schema(
     sex: String,
     height: Number,
     currentWeight: Number,
+    targetWeight: Number,
+    weightHistory: [
+      {
+        weight: Number,
+        date: { type: Date, default: Date.now },
+      },
+    ],
     diet: String,
     gymRoutine: String,
     role: { type: String, enum: ["user", "nutritionist"], default: "user" },


### PR DESCRIPTION
## Summary
- extend user model with weight goal and history fields
- show a circular progress indicator on the profile page
- allow editing current weight and target weight

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b3e3c2e7c832b8eaabf8a9112220e